### PR TITLE
Fixing bug

### DIFF
--- a/mods/deathmatch/resources/[vehicle]/carshop-system/s_shop.lua
+++ b/mods/deathmatch/resources/[vehicle]/carshop-system/s_shop.lua
@@ -274,9 +274,11 @@ function carshop_buyVehicle(paymentMethod)
 		if costCar <= 35000 then
 			if not exports.global:takeItem(client, 263) then
 				outputChatBox("There was an issue processing your request.", client, 255, 0 ,0)
+				return false
 			end
 		else
 			outputChatBox("You cannot use a token on a car worth over $35,000.", client, 255, 0, 0)
+			return false
 		end
 	else
 		if isOverlayDisabled then


### PR DESCRIPTION
So after brain stomring of ways to exploit this vulnerability, the only way i was able to exploit it is by buying two vehicles with one token, however i was unable to find a way to buy a vehicle +35k because of `if gui["_root"] then return end`. the serverside has no `return false` and it continues directly to giving the player the car even when exceptions happen similar to an old bug that enabled players to buy cars with no bankmoney. this code should fix it