### PR TITLE
Apps clicking bug.

### DIFF
--- a/mods/deathmatch/resources/phone/phone_core_c.lua
+++ b/mods/deathmatch/resources/phone/phone_core_c.lua
@@ -23,7 +23,7 @@ function drawPhoneGUI()
 	
 	wPhoneMenu = guiCreateStaticImage(posX, posY,w,h,"images/iphone_front.png",false)
 	phoneBackground = guiCreateStaticImage(0.085, 0.15, 0.83, 0.71, "images/backgrounds/Mountains.png", true, wPhoneMenu)
-	guiMoveToBack( phoneBackground )
+	--guiMoveToBack( phoneBackground ) don't use it, because it is will be set the phone apps doesn't click.
 	guiSetEnabled( phoneBackground, false )
 
 	local btnW, btnH = 105, 30


### PR DESCRIPTION
Hi, I saw that there is a problem with the GUI of the phone when I open it, I can only click on apps when I press the **'Home'** button but when I found `'guiMoveToBack'` I removed it and things are back to normal.