### PR TITLE
BUG - buying a vehicle from carshop far of the pickup.

### DIFF
--- a/mods/deathmatch/resources/[vehicle]/carshop-system/c_shop.lua
+++ b/mods/deathmatch/resources/[vehicle]/carshop-system/c_shop.lua
@@ -107,10 +107,14 @@ function carshop_buyCar_close()
 	end
 	guiSetInputEnabled(false)
 	setElementData(getLocalPlayer(), "exclusiveGUI", false, false)
+	setElementData(getLocalPlayer(), "carshopfix", false)
+	setElementFrozen(getLocalPlayer(), false)
 end
 --PREVENT ABUSER TO CHANGE CHAR
 addEventHandler ( "account:changingchar", getRootElement(), carshop_buyCar_close )
 addEventHandler("onClientChangeChar", getRootElement(), carshop_buyCar_close)
+addEventHandler("CarshopFix", getRootElement(), carshop_buyCar_close)
+addEvent("CarshopFix", true)
 
 function cleanUp()
 	setElementData(getLocalPlayer(), "exclusiveGUI", false, false)


### PR DESCRIPTION
I have been try to buy a new vehicle, but if i go away from the pickup and click '**F**' button i'll get the GUI, I'm edited this bug and fixed.