### PR TITLE
BUG - buying a vehicle from carshop far of the pickup (server-side).

### DIFF
--- a/mods/deathmatch/resources/[vehicle]/carshop-system/s_shop.lua
+++ b/mods/deathmatch/resources/[vehicle]/carshop-system/s_shop.lua
@@ -169,6 +169,7 @@ function carshop_pickupUse(thePlayer)
 		local costTax = getElementData(parentCar, "carshop:taxcost")
 		if costCar and costTax then
 			triggerClientEvent(thePlayer, "carshop:showInfo", parentCar, costCar, costTax)
+			setElementData(thePlayer, "carshopfix", true)
 		end
 		cancelEvent()
 	end
@@ -202,7 +203,8 @@ addEventHandler( "onResourceStart", getResourceRootElement(), carshop_Initalize)
 
 function carshop_blockEnterVehicle(thePlayer)
 	local isCarShop = getElementData(source, "carshop")
-	if (isCarShop) then
+	local isInCarShop = getElementData(thePlayer, "carshopfix")
+	if (isCarShop and isInCarShop) then
 		local costCar = getElementData(source, "carshop:cost")
 
 		local payByCash = true
@@ -216,7 +218,7 @@ function carshop_blockEnterVehicle(thePlayer)
 		if money < 0 or costCar == 0 then
 			payByBank = false
 		end
-
+		setElementFrozen(thePlayer, true)
 		triggerClientEvent(thePlayer, "carshop:buyCar", source, costCar, payByCash, payByBank)
 	end
 	cancelEvent()


### PR DESCRIPTION
I have been try to buy a new vehicle, but if i go away from the pickup and click '**F**' button i'll get the GUI, I'm edited this bug and fixed.

note: sorry for spamming in pull request, i have been tried to find how can i edit multi files in this repo 💌.